### PR TITLE
add boto3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm==4.26.0
 termcolor==1.1.0
 pandas==0.23.4
 fairseq==0.6.1
+boto3


### PR DESCRIPTION
When downloading models I got this error:

```
...
bert-large-cased.tar.gz                            100%[================================================================================================================>]   1.16G  50.0MB/s    in 25s

2019-04-11 09:55:23 (48.2 MB/s) - ‘bert-large-cased.tar.gz’ saved [1242874899/1242874899]

Building common vocab
Traceback (most recent call last):
  File "lama/vocab_intersection.py", line 7, in <module>
    from lama.modules import build_model_by_name
  File "/private/home/ahm/LAMA/lama/modules/__init__.py", line 7, in <module>
    from .bert_connector import Bert
  File "/private/home/ahm/LAMA/lama/modules/bert_connector.py", line 8, in <module>
    import pytorch_pretrained_bert.tokenization as btok
  File "/private/home/ahm/miniconda3/lib/python3.6/site-packages/pytorch_pretrained_bert-0.6.1-py3.6.egg/pytorch_pretrained_bert/__init__.py", line 2, in <module>
    from .tokenization import BertTokenizer, BasicTokenizer, WordpieceTokenizer
  File "/private/home/ahm/miniconda3/lib/python3.6/site-packages/pytorch_pretrained_bert-0.6.1-py3.6.egg/pytorch_pretrained_bert/tokenization.py", line 25, in <module>
    from .file_utils import cached_path
  File "/private/home/ahm/miniconda3/lib/python3.6/site-packages/pytorch_pretrained_bert-0.6.1-py3.6.egg/pytorch_pretrained_bert/file_utils.py", line 18, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
```

I'm not sure if there's a version you want, though?