### PR TITLE
Add colorama to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm==4.26.0
 termcolor==1.1.0
 pandas==0.23.4
 fairseq==0.6.1
+colorama==0.4.1


### PR DESCRIPTION
Missing requirement on at least OSX with anaconda environment while
following README install steps.