### PR TITLE
Add `conda install gcc` as setup step for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To reproduce our results:
 (optional) It might be a good idea to use a separate conda environment. It can be created by running:
 ```
 conda create -n lama37 -y python=3.7 && conda activate lama37
+conda install gcc
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Sometimes, on MacOS, the headers with gcc will not be found without
installing gcc with conda. Adding this step to the README will
address this issue for future users.