### PR TITLE
Fix wrong `fairseq` version in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 from setuptools import setup, find_packages
 
-requirements = ['Cython==0.29.2', 'numpy==1.15.1', 'torch==1.0.1', 'pytorch-pretrained-bert==0.6.1', 'allennlp==0.7.1', 'spacy==2.0.17', 'tqdm==4.26.0', 'termcolor==1.1.0', 'pandas==0.23.4', 'fairseq==0.6.1', 'scipy==1.3.2']
+requirements = ['Cython==0.29.2', 'numpy==1.15.1', 'torch==1.0.1', 'pytorch-pretrained-bert==0.6.1', 'allennlp==0.7.1', 'spacy==2.0.17', 'tqdm==4.26.0', 'termcolor==1.1.0', 'pandas==0.23.4', 'fairseq==0.8.0', 'scipy==1.3.2']
 setup(
     name = 'LAMA',
     version = '0.1.2',


### PR DESCRIPTION
When I install LAMA via pip (command: `pip install --editable .`) and run the sentence filling script (`lama/eval_generation.py`), the following error occurs:
```bash
Traceback (most recent call last):
  File "lama/eval_generation.py", line 7, in <module>
    from lama.modules import build_model_by_name
  File "/home/feabries/projects/LAMA/lama/modules/__init__.py", line 11, in <module>
    from .roberta_connector import Roberta
  File "/home/feabries/projects/LAMA/lama/modules/roberta_connector.py", line 7, in <module>
    from fairseq.models.roberta import RobertaModel
ModuleNotFoundError: No module named 'fairseq.models.roberta'
```

The error comes from the line in `lama/modules/roberta_connector.py`, which imports Roberta model class using `fairseq`:
https://github.com/facebookresearch/LAMA/blob/5cba81b6e55d4c596ce62b0166b1acd429a47f28/lama/modules/roberta_connector.py#L7

It seems that the versions of `fairseq` in `requirements.txt` and `setup.py` are different (#42). The above code works fine for `fairseq==0.8.0`, but fails on `fairseq==0.6.1`, so I change the `fairseq` version to `0.8.0` in `setup.py` in the pull request.